### PR TITLE
Error Embed Names

### DIFF
--- a/src/Events/ready.js
+++ b/src/Events/ready.js
@@ -17,7 +17,10 @@ process.on('uncaughtException', (err) => {
                     name: `${err.name}`
                 },
                 description: `${err.stack}`,
-                color: 'NOT_QUITE_BLACK'
+                color: 'NOT_QUITE_BLACK',
+                footer: {
+                  text: "Uncaught Exception"
+                }
             }
         ]
     })
@@ -33,7 +36,10 @@ process.on('unhandledRejection', (err) => {
                     name: `${err.name}`
                 },
                 description: `${err.stack}`,
-                color: 'NOT_QUITE_BLACK'
+                color: 'NOT_QUITE_BLACK',
+                footer: {
+                  text: "Unhandled Rejection"
+                }
             }
         ]
     })

--- a/src/Events/ready.js
+++ b/src/Events/ready.js
@@ -14,9 +14,9 @@ process.on('uncaughtException', (err) => {
         embeds: [
             {
                 author: {
-                    name: `[UNCAUGHT EXCEPTION]`
+                    name: `${err.name}`
                 },
-                description: `${err}`,
+                description: `${err.stack}`,
                 color: 'NOT_QUITE_BLACK'
             }
         ]
@@ -30,9 +30,9 @@ process.on('unhandledRejection', (err) => {
         embeds: [
             {
                 author: {
-                    name: `[UNHANDLED REJECTION]`
+                    name: `${err.name}`
                 },
-                description: `${err}`,
+                description: `${err.stack}`,
                 color: 'NOT_QUITE_BLACK'
             }
         ]


### PR DESCRIPTION
# Error Embed Name Change
> Make embed author name to the error name so it knows what the error name is, instead of uncaught exception only because it's weird and it doesn't really mean anything.